### PR TITLE
make sure destination only contains the hostname value and not whole URL

### DIFF
--- a/src/main/java/io/kamax/mxisd/session/SessionManager.java
+++ b/src/main/java/io/kamax/mxisd/session/SessionManager.java
@@ -284,7 +284,7 @@ public class SessionManager {
         jsonObject.addProperty("method", "POST");
         jsonObject.addProperty("uri", "/_matrix/identity/api/v1/3pid/unbind");
         jsonObject.addProperty("origin", origin);
-        jsonObject.addProperty("destination_is", cfg.getServer().getPublicUrl());
+        jsonObject.addProperty("destination_is", URI.create(cfg.getServer().getPublicUrl()).getHost());
         jsonObject.add("content", reqData);
 
         String canonical = MatrixJson.encodeCanonical(jsonObject);

--- a/src/main/java/io/kamax/mxisd/session/SessionManager.java
+++ b/src/main/java/io/kamax/mxisd/session/SessionManager.java
@@ -57,6 +57,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Calendar;


### PR DESCRIPTION
When testing this, the public URL is containing the protocol "https://" which differs from synapse's values. This code makes sure to remove that extra data to signatures match. Is there ever a situation in which the public url is any different?