### PR TITLE
Allow configuring unbind notifications to be sent or not.

### DIFF
--- a/docs/threepids/session/session.md
+++ b/docs/threepids/session/session.md
@@ -103,8 +103,7 @@ session:
     validation:
       enabled: true
     unbind:
-      notification:
-        enabled: true
+      notifications: true
 
 # DO NOT COPY/PASTE AS-IS IN YOUR CONFIGURATION
 # CONFIGURATION EXAMPLE
@@ -115,7 +114,7 @@ are allowed to do in terms of 3PID sessions. The policy has a global on/off swit
 
 ---
 
-`unbind` controls warning notifications for 3PID removal.  
+`unbind` controls warning notifications for 3PID removal. Settings `notifications` for `unbind` to false will prevent unbind emails from sending.
 
 ### Web views
 Once a user click on a validation link, it is taken to the Identity Server validation page where the token is submitted.  

--- a/docs/threepids/session/session.md
+++ b/docs/threepids/session/session.md
@@ -114,7 +114,7 @@ are allowed to do in terms of 3PID sessions. The policy has a global on/off swit
 
 ---
 
-`unbind` controls warning notifications for 3PID removal. Settings `notifications` for `unbind` to false will prevent unbind emails from sending.
+`unbind` controls warning notifications for 3PID removal. Setting `notifications` for `unbind` to false will prevent unbind emails from sending.
 
 ### Web views
 Once a user click on a validation link, it is taken to the Identity Server validation page where the token is submitted.  

--- a/src/main/java/io/kamax/mxisd/config/SessionConfig.java
+++ b/src/main/java/io/kamax/mxisd/config/SessionConfig.java
@@ -47,6 +47,8 @@ public class SessionConfig {
         public static class PolicyUnbind {
 
             private boolean enabled = true;
+            
+            private boolean notifications = true;
 
             public boolean getEnabled() {
                 return enabled;
@@ -55,11 +57,20 @@ public class SessionConfig {
             public void setEnabled(boolean enabled) {
                 this.enabled = enabled;
             }
+            
+            public boolean shouldNotify() {
+                return notifications;
+            }
+            
+            public void setNotifications(boolean notifications) {
+                this.notifications = notifications;
+            }
         }
 
         public Policy() {
             validation.enabled = true;
             unbind.enabled = true;
+            unbind.notifications = true;
         }
 
         private PolicyTemplate validation = new PolicyTemplate();

--- a/src/main/java/io/kamax/mxisd/session/SessionManager.java
+++ b/src/main/java/io/kamax/mxisd/session/SessionManager.java
@@ -234,7 +234,9 @@ public class SessionManager {
         }
 
         log.info("Unbinding of {} {} to {} is accepted", tpid.getMedium(), tpid.getAddress(), mxid.getId());
-        notifMgr.sendForUnbind(tpid);
+        if (cfg.getSession().getPolicy().getUnbind().shouldNotify()) {
+            notifMgr.sendForUnbind(tpid);
+        }
     }
 
     private void checkAuthorization(String auth, JsonObject reqData) {


### PR DESCRIPTION
The old docs from mxisd seemed to imply you could stop sending unbind notifications but that doesn't seem to exist. This adds this function to the session config and has the session manager take it into account when about to notify.