### PR TITLE
Load DNS overwrite config on startup and remove duplicates from identity store before email notifications

### DIFF
--- a/src/main/java/io/kamax/mxisd/as/processor/event/MembershipEventProcessor.java
+++ b/src/main/java/io/kamax/mxisd/as/processor/event/MembershipEventProcessor.java
@@ -144,7 +144,13 @@ public class MembershipEventProcessor implements EventTypeProcessor {
                 .collect(Collectors.toList());
         log.info("Found {} email(s) in identity store for {}", tpids.size(), inviteeId);
 
-        for (_ThreePid tpid : tpids) {
+        log.info("Removing duplicates from identity store");
+        List<_ThreePid> uniqueTpids = tpids.stream()
+                .distinct()
+                .collect(Collectors.toList());
+        log.info("There are {} unique email(s) in identity store for {}", uniqueTpids.size(), inviteeId);        
+
+        for (_ThreePid tpid : uniqueTpids) {
             log.info("Found Email to notify about room invitation: {}", tpid.getAddress());
             Map<String, String> properties = new HashMap<>();
             profiler.getDisplayName(sender).ifPresent(name -> properties.put("sender_display_name", name));

--- a/src/main/java/io/kamax/mxisd/config/MxisdConfig.java
+++ b/src/main/java/io/kamax/mxisd/config/MxisdConfig.java
@@ -359,6 +359,7 @@ public class MxisdConfig {
         getAuth().build();
         getAccountConfig().build();
         getDirectory().build();
+        getDns().build();
         getExec().build();
         getFirebase().build();
         getForward().build();


### PR DESCRIPTION
I recently noticed that DNS overwrite does not happen. There are messages in logs: "No DNS overwrite for <REDACTED>", but I definitely have configured DNS overwrithng. I think it's because DNS overwriting config is not loaded when ma1sd starts up.
Documented here: https://github.com/ma1uta/ma1sd/blob/master/docs/features/authentication.md#dns-overwrite and here: https://github.com/ma1uta/ma1sd/blob/master/docs/features/directory.md#dns-overwrite