### PR TITLE
Fix room name retrieval after Synapse dropped table room_names

### DIFF
--- a/src/main/java/io/kamax/mxisd/backend/sql/synapse/SynapseQueries.java
+++ b/src/main/java/io/kamax/mxisd/backend/sql/synapse/SynapseQueries.java
@@ -72,7 +72,7 @@ public class SynapseQueries {
     }
 
     public static String getRoomName() {
-        return "select r.name from room_names r, events e, (select r1.room_id,max(e1.origin_server_ts) ts from room_names r1, events e1 where r1.event_id = e1.event_id group by r1.room_id) rle where e.origin_server_ts = rle.ts and r.event_id = e.event_id and r.room_id = ?";
+        return "select name from room_stats_state where room_id = ? limit 1";
     }
 
 }


### PR DESCRIPTION
Recently Synapse dropped unused (by Synapse itself) table "room_names" which brakes room name retrieval for ma1sd. There is a table "room_stats_state" from which we can retrieve room name by it's ID. Note that people to people conversations do not contain room names, because they are generated on-the-fly by setting other participants names separated by word "and". That's why this query will only get names for rooms where room names are set during creation process (or changed later) and are the same for all participants.
Link to Synapse code where it drops "room_names" table: https://github.com/matrix-org/synapse/blob/master/synapse/storage/data_stores/main/schema/delta/56/drop_unused_event_tables.sql#L17