### PR TITLE
Make all 3PID address lowercase to avoid duplicates

### DIFF
--- a/src/main/java/io/kamax/matrix/ThreePid.java
+++ b/src/main/java/io/kamax/matrix/ThreePid.java
@@ -27,7 +27,7 @@ public class ThreePid implements _ThreePid {
 
     public ThreePid(String medium, String address) {
         this.medium = medium;
-        this.address = address;
+        this.address = address.toLowerCase();
     }
 
     @Override


### PR DESCRIPTION
These changes complement #11 where locally saved e-mail address can be "name.surname@example.com", but e-mail address in LDAP can be "Name.Surname@example.com". They are treated as two different e-mail addresses and user gets 2 invitation notification e-mails. We change ThreePid model's address property to convert all info to lowercase and [be915ae](https://github.com/ma1uta/ma1sd/commit/be915aed947a6d38e5f26f0a7834d12e3a0799f2) can do it's job better.
The downside of this is that all medium addresses get converted to lowercase, not only e-mails. For now I can't think of any examples where medium values need to stay case sensitive.