### PR TITLE
Docker build cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine AS builder
+FROM --platform=$BUILDPLATFORM openjdk:8-jre-alpine AS builder
 
 RUN apk update && apk add gradle git && rm -rf /var/lib/apk/* /var/cache/apk/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+FROM openjdk:8-jre-alpine AS builder
+
+RUN apk update && apk add gradle git && rm -rf /var/lib/apk/* /var/cache/apk/*
+
+WORKDIR /ma1sd
+COPY . .
+RUN ./gradlew shadowJar
+
 FROM openjdk:8-jre-alpine
 
 RUN apk update && apk add bash && rm -rf /var/lib/apk/* /var/cache/apk/*
@@ -15,4 +23,4 @@ CMD [ "/start.sh" ]
 
 ADD src/docker/start.sh /start.sh
 ADD src/script/ma1sd /app/ma1sd
-ADD build/libs/ma1sd.jar /app/ma1sd.jar
+COPY --from=builder /ma1sd/build/libs/ma1sd.jar /app/ma1sd.jar

--- a/build.gradle
+++ b/build.gradle
@@ -275,22 +275,10 @@ task dockerBuild(type: Exec) {
 }
 
 task dockerBuildX(type: Exec, dependsOn: shadowJar) {
-    commandLine 'docker', 'buildx', 'build', '--load', '--platform', 'linux/arm64', '-t', dockerImageTag + '-arm64', project.rootDir
+    commandLine 'docker', 'buildx', 'build', '--push', '--platform', 'linux/arm64,linux/amd64,linux/arm/v7', '-t', dockerImageTag , project.rootDir
     doLast {
         exec {
-            commandLine 'docker', 'buildx', 'build', '--load', '--platform', 'linux/amd64', '-t', dockerImageTag + '-amd64', project.rootDir
-        }
-
-        exec {
-            commandLine 'docker', 'tag', dockerImageTag + '-arm64', "${dockerImageName}:latest-arm64-dev"
-        }
-
-        exec {
-            commandLine 'docker', 'tag', dockerImageTag + '-amd64', "${dockerImageName}:latest-amd64-dev"
-        }
-
-        exec {
-            commandLine 'docker', 'tag', dockerImageTag + '-amd64', "${dockerImageName}:latest-dev"
+            commandLine 'docker', 'buildx', 'build', '--push', '--platform', 'linux/arm64,linux/amd64,linux/arm/v7', '-t', "${dockerImageName}:latest-dev", project.rootDir
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -264,7 +264,7 @@ task debBuild(dependsOn: shadowJar) {
     }
 }
 
-task dockerBuild(type: Exec, dependsOn: shadowJar) {
+task dockerBuild(type: Exec) {
     commandLine 'docker', 'build', '-t', dockerImageTag, project.rootDir
 
     doLast {


### PR DESCRIPTION
Build a single-arch Docker image without requiring Gradle or JDK on the host system.
Build multi-arch Docker images with universal image tags.

Below is output from a Raspberry Pi 3 running a single-arch build to show this works:
```sh
root@ruby:/home/mattcen/ma1sd# ./gradlew dockerBuild
Starting a Gradle Daemon, 1 stopped Daemon could not be reused, use --status for details

> Task :dockerBuild
Sending build context to Docker daemon  4.279MB

Step 1/19 : FROM openjdk:8-jre-alpine AS builder
 ---> 0e9bfd1ff5bf
Step 2/19 : RUN apk update && apk add gradle git && rm -rf /var/lib/apk/* /var/cache/apk/*
 ---> Using cache
 ---> ffabf2e71c74
Step 3/19 : WORKDIR /ma1sd
 ---> Using cache
 ---> 44529e92aa15
Step 4/19 : COPY . .
 ---> e6734ae0f784
Step 5/19 : RUN ./gradlew
 ---> Running in 627d5c2d168b
Downloading https://services.gradle.org/distributions/gradle-6.0-all.zip
......................................................................................................................................

Welcome to Gradle 6.0!

Here are the highlights of this release:
 - Substantial improvements in dependency management, including
   - Publishing Gradle Module Metadata in addition to pom.xml
   - Advanced control of transitive versions
   - Support for optional features and dependencies
   - Rules to tweak published metadata
 - Support for Java 13
 - Faster incremental Java and Groovy compilation
 - New Zinc compiler for Scala
 - VS2019 support
 - Support for Gradle Enterprise plugin 3.0

For more details see https://docs.gradle.org/6.0/release-notes.html

Starting a Gradle Daemon (subsequent builds will be faster)

> Task :help

Welcome to Gradle 6.0.

To run a build, run gradlew <task> ...

To see a list of available tasks, run gradlew tasks

To see a list of command-line options, run gradlew --help

To see more detail about a task, run gradlew help --task <task>

For troubleshooting, visit https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.0/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 39m 32s
1 actionable task: 1 executed
Removing intermediate container 627d5c2d168b
 ---> dfec66aba3f7
Step 6/19 : RUN ./gradlew shadowJar
 ---> Running in 8f98760c2c66
Starting a Gradle Daemon, 1 incompatible and 1 stopped Daemons could not be reused, use --status for details
> Task :compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :processResources
> Task :classes
> Task :shadowJar

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.0/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 44m 41s
3 actionable tasks: 3 executed
Removing intermediate container 8f98760c2c66
 ---> 0ff06210b831
Step 7/19 : FROM openjdk:8-jre-alpine
 ---> 0e9bfd1ff5bf
Step 8/19 : RUN apk update && apk add bash && rm -rf /var/lib/apk/* /var/cache/apk/*
 ---> Running in ec074bf0fd88
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/main/armv7/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/community/armv7/APKINDEX.tar.gz
v3.9.6-42-g88b6599af0 [http://dl-cdn.alpinelinux.org/alpine/v3.9/main]
v3.9.6-46-g228dc16f63 [http://dl-cdn.alpinelinux.org/alpine/v3.9/community]
OK: 9573 distinct packages available
(1/5) Installing ncurses-terminfo-base (6.1_p20190105-r0)
(2/5) Installing ncurses-terminfo (6.1_p20190105-r0)
(3/5) Installing ncurses-libs (6.1_p20190105-r0)
(4/5) Installing readline (7.0.003-r1)
(5/5) Installing bash (4.4.19-r1)
Executing bash-4.4.19-r1.post-install
Executing busybox-1.29.3-r10.trigger
OK: 76 MiB in 58 packages
Removing intermediate container ec074bf0fd88
 ---> 2771837ce66b
Step 9/19 : VOLUME /etc/ma1sd
 ---> Running in f7651aed63ca
Removing intermediate container f7651aed63ca
 ---> 33f72c06cf00
Step 10/19 : VOLUME /var/ma1sd
 ---> Running in 49d452678a9f
Removing intermediate container 49d452678a9f
 ---> 858435098f3a
Step 11/19 : EXPOSE 8090
 ---> Running in 273b6f32f005
Removing intermediate container 273b6f32f005
 ---> 5434a3fb7c07
Step 12/19 : ENV JAVA_OPTS=""
 ---> Running in d7c47f5abf1d
Removing intermediate container d7c47f5abf1d
 ---> 2183fc5ee4cd
Step 13/19 : ENV CONF_FILE_PATH="/etc/ma1sd/ma1sd.yaml"
 ---> Running in f933b40d9988
Removing intermediate container f933b40d9988
 ---> 854cb0798bd6
Step 14/19 : ENV SIGN_KEY_PATH="/var/ma1sd/sign.key"
 ---> Running in 223e967ba9d2
Removing intermediate container 223e967ba9d2
 ---> 8ea9f96b6543
Step 15/19 : ENV SQLITE_DATABASE_PATH="/var/ma1sd/ma1sd.db"
 ---> Running in e36891b3b692
Removing intermediate container e36891b3b692
 ---> fed9aa6e6a79
Step 16/19 : CMD [ "/start.sh" ]
 ---> Running in 9c3019d1b488
Removing intermediate container 9c3019d1b488
 ---> 85b7d5725852
Step 17/19 : ADD src/docker/start.sh /start.sh
 ---> 23f93d7be02f
Step 18/19 : ADD src/script/ma1sd /app/ma1sd
 ---> 6c896c8ea107
Step 19/19 : COPY --from=builder /ma1sd/build/libs/ma1sd.jar /app/ma1sd.jar
 ---> 4dfc0300ca4d
Successfully built 4dfc0300ca4d
Successfully tagged ma1uta/ma1sd:2.4.0-dirty

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.0/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1h 27m 43s
1 actionable task: 1 executed
```