### PR TITLE
Support for Active Directory multidomain forest

### DIFF
--- a/ma1sd.example.yaml
+++ b/ma1sd.example.yaml
@@ -165,6 +165,8 @@ threepid:
 # ldap:
 #   enabled: true
 #   lookup: true # hash lookup
+#   activeDirectory: false
+#   defaultDomain: ''
 #   connection:
 #     host: 'ldap.domain.tld'
 #     port: 389

--- a/src/main/java/io/kamax/mxisd/config/ldap/LdapConfig.java
+++ b/src/main/java/io/kamax/mxisd/config/ldap/LdapConfig.java
@@ -291,6 +291,9 @@ public abstract class LdapConfig {
     private boolean enabled;
     private String filter;
 
+    private boolean activeDirectory;
+    private String defaultDomain;
+
     private Connection connection = new Connection();
     private Attribute attribute = new Attribute();
     private Auth auth = new Auth();
@@ -314,6 +317,22 @@ public abstract class LdapConfig {
 
     public void setFilter(String filter) {
         this.filter = filter;
+    }
+
+    public boolean isActiveDirectory() {
+        return activeDirectory;
+    }
+
+    public void setActiveDirectory(boolean activeDirectory) {
+        this.activeDirectory = activeDirectory;
+    }
+
+    public String getDefaultDomain() {
+        return defaultDomain;
+    }
+
+    public void setDefaultDomain(String defaultDomain) {
+        this.defaultDomain = defaultDomain;
     }
 
     public Connection getConnection() {
@@ -405,6 +424,15 @@ public abstract class LdapConfig {
 
         if (StringUtils.isBlank(identity.getToken())) {
             throw new ConfigurationException("ldap.identity.token");
+        }
+
+        if(isActiveDirectory()) {
+            if(!StringUtils.equals(LdapBackend.UID, uidType)) {
+                throw new IllegalArgumentException(String.format(
+                    "Attribute UID type should be set to %s in Active Directory mode",
+                    LdapBackend.UID
+                ));
+            }
         }
 
         // Build queries


### PR DESCRIPTION
This commit reflects proposed [1] changes in ldap_auth_provider that adds mxid generation logic for Active Directory.

Please note that I didn't tested this change in production environment, but I will try to test it this week.

[1] https://github.com/matrix-org/matrix-synapse-ldap3/pull/93