### PR TITLE
Force MatrixID to be lowercase

### DIFF
--- a/src/main/java/io/kamax/mxisd/backend/ldap/LdapBackend.java
+++ b/src/main/java/io/kamax/mxisd/backend/ldap/LdapBackend.java
@@ -117,11 +117,15 @@ public abstract class LdapBackend {
 
     public String buildMatrixIdFromUid(String uid) {
         String uidType = getCfg().getAttribute().getUid().getType();
-        String localpart = uid;
+        String localpart = uid.toLowerCase();
+
+        if (!StringUtils.equals(uid, localpart)) {
+            log.info("UID {} from LDAP has been changed to lowercase to match the Synapse specifications", uid);
+        }
 
         if (StringUtils.equals(UID, uidType)) {
             if(getCfg().isActiveDirectory()) {
-                localpart  = new UPN(uid).getMXID();
+                localpart  = new UPN(uid.toLowerCase()).getMXID();
             }
 
             return "@" + localpart + ":" + mxCfg.getDomain();


### PR DESCRIPTION
I tried to fix the problem, that so far the UIDs from a LDAP backend which does not provide lowercase strings are refused due to to lower case policy of Synapse/Matrix (resolves #63).

As I am not really familiar with the code don't expect it to be completely free of errors/that I didn't miss something important.
I ran the  `gradle check` and `gradle test` tools but couldn't test it on a running instance.

I hope this helps and if you have any remarks please let me know :smiley: 

