### PR TITLE
#76 Set a message for error responses

### DIFF
--- a/src/main/java/io/kamax/mxisd/exception/InvalidParamException.java
+++ b/src/main/java/io/kamax/mxisd/exception/InvalidParamException.java
@@ -23,5 +23,6 @@ package io.kamax.mxisd.exception;
 public class InvalidParamException extends RuntimeException {
 
     public InvalidParamException() {
+        super("The chosen hash algorithm is invalid or disallowed");
     }
 }

--- a/src/main/java/io/kamax/mxisd/exception/InvalidPepperException.java
+++ b/src/main/java/io/kamax/mxisd/exception/InvalidPepperException.java
@@ -23,5 +23,6 @@ package io.kamax.mxisd.exception;
 public class InvalidPepperException extends RuntimeException {
 
     public InvalidPepperException() {
+        super("The provided pepper is invalid or expired");
     }
 }

--- a/src/main/java/io/kamax/mxisd/http/undertow/handler/BasicHttpHandler.java
+++ b/src/main/java/io/kamax/mxisd/http/undertow/handler/BasicHttpHandler.java
@@ -189,7 +189,7 @@ public abstract class BasicHttpHandler implements HttpHandler {
     }
 
     protected void respond(HttpServerExchange ex, int status, String errCode, String error) {
-        respond(ex, status, buildErrorBody(ex, errCode, error));
+        respond(ex, status, buildErrorBody(ex, errCode, error != null ? error : "An error has occurred"));
     }
 
     protected void handleException(HttpServerExchange exchange, HttpMatrixException ex) {


### PR DESCRIPTION
Without one, clients might treat errors as generic failures instead of
handling them in a manner appropriate for their error code

---

This prevents Element Android from failing and displaying an `M_INVALID_PEPPER` error dialog on the Discovery screen after the pepper has been rotated.

A follow-up issue remains: after a new pepper is obtained after `M_INVALID_PEPPER` and is used for the first time, the first lookup doesn't find any bindings. Only exiting the Discovery page and going back lets bindings be found. Maybe this is an issue with my setup, though (see #76 for my config).