### PR TITLE
mention Java 11 dependency

### DIFF
--- a/docs/install/debian.md
+++ b/docs/install/debian.md
@@ -1,6 +1,6 @@
 # Debian package
 ## Requirements
-- Any distribution that supports Java 8
+- Any distribution that supports Java 11 or Java 8
 
 ## Install
 1. Download the [latest release](https://github.com/ma1uta/ma1sd/releases/latest)


### PR DESCRIPTION
According to the [changelog](https://github.com/ma1uta/ma1sd/releases/tag/2.0.0) and the dependencies in the Debian package either Java 11 or Java 8 work.