### PR TITLE
Add avatar to Synapse User Directory search response

### DIFF
--- a/src/main/java/io/kamax/mxisd/backend/firebase/GoogleFirebaseAuthenticator.java
+++ b/src/main/java/io/kamax/mxisd/backend/firebase/GoogleFirebaseAuthenticator.java
@@ -109,7 +109,7 @@ public class GoogleFirebaseAuthenticator extends GoogleFirebaseBackend implement
         CountDownLatch l = new CountDownLatch(1);
         getFirebase().verifyIdToken(password).addOnSuccessListener(token -> {
             try {
-                if (!StringUtils.equals(localpart, token.getUid())) {
+                if (!StringUtils.equals(localpart, token.getUid().toLowerCase())) {
                     log.info("Failure to authenticate {}: Matrix ID localpart '{}' does not match Firebase UID '{}'", mxid, localpart, token.getUid());
                     result.fail();
                     return;

--- a/src/main/java/io/kamax/mxisd/backend/firebase/GoogleFirebaseBackend.java
+++ b/src/main/java/io/kamax/mxisd/backend/firebase/GoogleFirebaseBackend.java
@@ -55,6 +55,8 @@ public class GoogleFirebaseBackend {
             log.info("Google Firebase Authentication is ready");
         } catch (IOException e) {
             throw new RuntimeException("Error when initializing Firebase", e);
+        } catch (IllegalStateException e){
+            fbAuth = FirebaseAuth.getInstance(FirebaseApp.getInstance(name));
         }
     }
 

--- a/src/main/java/io/kamax/mxisd/backend/sql/generic/GenericSqlDirectoryProvider.java
+++ b/src/main/java/io/kamax/mxisd/backend/sql/generic/GenericSqlDirectoryProvider.java
@@ -65,6 +65,7 @@ public class GenericSqlDirectoryProvider implements DirectoryProvider {
         Result item = new Result();
         item.setUserId(rSet.getString(1));
         item.setDisplayName(rSet.getString(2));
+        item.setAvatarUrl(rSet.getString(3));
         return Optional.of(item);
     }
 

--- a/src/main/java/io/kamax/mxisd/backend/sql/synapse/SynapseQueries.java
+++ b/src/main/java/io/kamax/mxisd/backend/sql/synapse/SynapseQueries.java
@@ -51,7 +51,7 @@ public class SynapseQueries {
         if (StringUtils.equals("sqlite", type)) {
             return "select " + getUserId(type, domain) + ", displayname from profiles p where displayname like ?";
         } else if (StringUtils.equals("postgresql", type)) {
-            return "SELECT u.name,p.displayname FROM users u JOIN profiles p ON u.name LIKE concat('@',p.user_id,':%') WHERE u.is_guest = 0 AND u.appservice_id IS NULL AND p.displayname LIKE ?";
+            return "SELECT u.name,p.displayname,p.avatar_url FROM users u JOIN profiles p ON u.name LIKE concat('@',p.user_id,':%') WHERE u.is_guest = 0 AND u.appservice_id IS NULL AND p.displayname LIKE ?";
         } else {
             throw new ConfigurationException("Invalid Synapse SQL type: " + type);
         }
@@ -63,7 +63,7 @@ public class SynapseQueries {
                     "from user_threepids t JOIN profiles p on t.user_id = " + getUserId(type, domain) + " " +
                     "where t.address like ?";
         } else if (StringUtils.equals("postgresql", type)) {
-            return "select t.user_id, p.displayname " +
+            return "select t.user_id, p.displayname, p.avatar_url " +
                     "from user_threepids t JOIN profiles p on t.user_id = " + getUserId(type, domain) + " " +
                     "where t.address ilike ?";
         } else {


### PR DESCRIPTION
User Directory search was missing avatar, thus forcing Matrix client developers to make an extra roundtrip to the server to get avatar when showing search results.

This PR adds avatar_url into the response when fallbacking to Synapse DB.