### PR TITLE
Add /_matrix/identity/versions endpoint for Matrix v1.1

### DIFF
--- a/src/main/java/io/kamax/mxisd/HttpMxisd.java
+++ b/src/main/java/io/kamax/mxisd/HttpMxisd.java
@@ -67,6 +67,7 @@ import io.kamax.mxisd.http.undertow.handler.status.StatusHandler;
 import io.kamax.mxisd.http.undertow.handler.status.VersionHandler;
 import io.kamax.mxisd.http.undertow.handler.term.v2.AcceptTermsHandler;
 import io.kamax.mxisd.http.undertow.handler.term.v2.GetTermsHandler;
+import io.kamax.mxisd.http.undertow.handler.versions.VersionsHandler;
 import io.kamax.mxisd.matrix.IdentityServiceAPI;
 import io.undertow.Handlers;
 import io.undertow.Undertow;
@@ -140,6 +141,9 @@ public class HttpMxisd {
             .get("/users/{" + AsUserHandler.ID + "}", asUserHandler) // Legacy endpoint
             .get("/rooms/**", asNotFoundHandler) // Legacy endpoint
             .put("/transactions/{" + AsTransactionHandler.ID + "}", asTxnHandler) // Legacy endpoint
+
+            // Versions Endpoint
+            .get(VersionsHandler.Path, sane(new VersionsHandler()))
 
             // Banned endpoints
             .get(InternalInfoHandler.Path, sane(new InternalInfoHandler()));

--- a/src/main/java/io/kamax/mxisd/http/undertow/handler/versions/VersionsHandler.java
+++ b/src/main/java/io/kamax/mxisd/http/undertow/handler/versions/VersionsHandler.java
@@ -1,0 +1,21 @@
+package io.kamax.mxisd.http.undertow.handler.versions;
+
+import com.google.gson.JsonObject;
+import io.kamax.mxisd.http.undertow.handler.BasicHttpHandler;
+import io.undertow.server.HttpServerExchange;
+
+
+public class VersionsHandler extends BasicHttpHandler {
+
+    public static final String Path = "/_matrix/identity/versions";
+
+    public void handleRequest(HttpServerExchange exchange) {
+        JsonObject versions = new JsonObject();
+        versions.addProperty("versions", "[\"r0.3.0\"]");
+
+        JsonObject obj = new JsonObject();
+        obj.add("versions", versions);
+
+        respond(exchange, obj);
+    }
+}


### PR DESCRIPTION
This should tick off the first checkbox of #102 and matrix-org/sydent#424 for Matrix v1.1 support.