### PR TITLE
Fully qualify org.xbill.DNS.Record.

### DIFF
--- a/src/main/java/io/kamax/mxisd/matrix/HomeserverFederationResolver.java
+++ b/src/main/java/io/kamax/mxisd/matrix/HomeserverFederationResolver.java
@@ -143,13 +143,13 @@ public class HomeserverFederationResolver {
 
         try {
             List<SRVRecord> srvRecords = new ArrayList<>();
-            Record[] rawRecords = new Lookup(lookupDns, Type.SRV).run();
+            org.xbill.DNS.Record[] rawRecords = new Lookup(lookupDns, Type.SRV).run();
             if (Objects.isNull(rawRecords) || rawRecords.length == 0) {
                 log.debug("No SRV record for {}", domain);
                 return Optional.empty();
             }
 
-            for (Record record : rawRecords) {
+            for (org.xbill.DNS.Record record : rawRecords) {
                 if (Type.SRV == record.getType()) {
                     srvRecords.add((SRVRecord) record);
                 } else {

--- a/src/main/java/io/kamax/mxisd/matrix/IdentityServerUtils.java
+++ b/src/main/java/io/kamax/mxisd/matrix/IdentityServerUtils.java
@@ -108,13 +108,13 @@ public class IdentityServerUtils {
             log.info("Lookup name: {}", lookupDns);
 
             List<SRVRecord> srvRecords = new ArrayList<>();
-            Record[] records = new Lookup(lookupDns, Type.SRV).run();
+            org.xbill.DNS.Record[] records = new Lookup(lookupDns, Type.SRV).run();
             if (records == null || records.length == 0) {
                 log.info("No SRV record for {}", lookupDns);
                 return Optional.empty();
             }
 
-            for (Record record : records) {
+            for (org.xbill.DNS.Record record : records) {
                 log.info("Record: {}", record.toString());
                 if (record.getType() == Type.SRV) {
                     if (record instanceof SRVRecord) {


### PR DESCRIPTION
It collides with java.lang.Record added in Java 16. Even though this application does not formally support Java 16+, I hope it can be on a best-effort basis and this PR accepted.